### PR TITLE
Splits multi word themes/keywords in to single word arrays for easier Lunr matching

### DIFF
--- a/src/BuildLunrIndex.php
+++ b/src/BuildLunrIndex.php
@@ -110,14 +110,8 @@ class BuildLunrIndex {
   public function getTerms($item) {
     $output = [];
     $terms = [];
-
     if (is_array($item)) {
-      foreach($item as $term) {
-        $exploded = explode(" ", strtolower($term));
-        foreach($exploded as $sub_term) {
-          $terms[] = $sub_term;
-        }
-      }
+      $terms = $this->explodeItem($item);
     }
     else {
       $terms = explode(" ", $item);
@@ -126,6 +120,16 @@ class BuildLunrIndex {
       $output[] = $this->clean($term);
     }
     return $output;
+  }
+
+  private function explodeItem($item) {
+    foreach($item as $term) {
+      $exploded = explode(" ", strtolower($term));
+      foreach($exploded as $sub_term) {
+        $terms[] = $sub_term;
+      }
+    }
+    return $terms;
   }
 
   private function clean(string $string) {

--- a/src/BuildLunrIndex.php
+++ b/src/BuildLunrIndex.php
@@ -109,8 +109,15 @@ class BuildLunrIndex {
 
   public function getTerms($item) {
     $output = [];
+    $terms = [];
+
     if (is_array($item)) {
-      $terms = $item;
+      foreach($item as $term) {
+        $exploded = explode(" ", strtolower($term));
+        foreach($exploded as $sub_term) {
+          $terms[] = $sub_term;
+        }
+      }
     }
     else {
       $terms = explode(" ", $item);


### PR DESCRIPTION
Lunr by default is expecting single word entries. If tags have spaces in them, it can be hard to perform searches on the frontend as spaces in search queries mean separate words to look up in the index. This update explodes the strings into arrays so we can do more specific searches on the frontend. 